### PR TITLE
re-initialize checkout flow when its succeeded

### DIFF
--- a/public/checkout.js
+++ b/public/checkout.js
@@ -56,6 +56,7 @@ async function handleSubmit(e) {
     // 新しいカードが保存されたら、保存済みカードリストを更新
     const customerId = getCustomerId();
   }
+  await initialize();
 
   setLoading(false);
 }

--- a/public/save-card.js
+++ b/public/save-card.js
@@ -76,6 +76,7 @@ async function handleSubmit(e) {
     const customerId = getCustomerId();
     await fetchSavedCards(customerId);
   }
+  await initialize();
 
   setLoading(false);
 }


### PR DESCRIPTION
payment intent / setup intentの処理が完了したら、新しく発行し直す。